### PR TITLE
fix #33 silencing dead vehicle Qs

### DIFF
--- a/client/src/components/combat/overlays/MatchOverModal.jsx
+++ b/client/src/components/combat/overlays/MatchOverModal.jsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import ReactModal from 'react-modal'
+import uuid from 'uuid/v4'
+
+class MatchOverModal extends React.Component {
+  render() {
+    return (
+      <>
+        <div>
+          <ReactModal className={'Modal.Content'} overlayClassName={'Modal.Overlay'} key={uuid()} isOpen={true}>
+            <fieldset className="ModalFieldset">
+              <span className="flexCentered">Match</span>
+              <span className="flexCentered">Over</span>
+            </fieldset>
+          </ReactModal>
+        </div>
+      </>
+    )
+  }
+}
+
+ReactModal.setAppElement('#root')
+
+export default (MatchOverModal)

--- a/client/src/components/combat/overlays/TimingOverlays.tsx
+++ b/client/src/components/combat/overlays/TimingOverlays.tsx
@@ -4,6 +4,7 @@ import SpeedModal from './timing/subphase2SetSpeeds/SpeedModal'
 import ManeuverModal from './timing/subphase4Maneuver/ManeuverModal'
 import FireModal from './timing/subphase5FireWeapons/FireModal'
 import DamageModal from './timing/subphase6Damage/DamageModal'
+import MatchOverModal from './MatchOverModal'
 import RevealSpeedChangeModal from './timing/subphase3RevealSpeedChange/RevealSpeedChangeModal'
 import uuid from 'uuid/v4'
 
@@ -35,6 +36,9 @@ class TimingOverlays extends React.Component<Props> {
     const subphase = this.props.matchData.match.time.phase.subphase
 
     switch (subphase) {
+      case '0_increment_time':
+        console.log(this.props.matchData)
+        return <MatchOverModal />
       case '1_start':
         break
       case '2_set_speeds':

--- a/client/src/components/combat/overlays/vehicle/KillMessage.tsx
+++ b/client/src/components/combat/overlays/vehicle/KillMessage.tsx
@@ -49,7 +49,7 @@ class KillMessage extends React.Component<Props> {
 
     return (
       <g>
-        <image x={x - 16} y={y - 30} width="45" height="45" href="/img/skull_and_bones.svg" />
+        <image x={x - 20} y={y - 30} width="60" height="60" href="/img/skull_and_bones.svg" />
         <text x={x} y={y} style={this.msgStyle()} dy="0">
           <tspan textAnchor="middle" x={x} dy="1em" style={this.nameStyle(killerPlayer.color)}>
             {killerPlayer.name}

--- a/client/src/components/combat/overlays/vehicle/modal/carInset/carComponents/Weapon.tsx
+++ b/client/src/components/combat/overlays/vehicle/modal/carInset/carComponents/Weapon.tsx
@@ -24,7 +24,7 @@ class Weapon extends React.Component<Props> {
         maxDp={this.props.weaponData.maxDamagePoints}
         name={this.props.weaponData.abbreviation}
         point={new Point({ x, y })}
-        poweredDown={this.props.poweredDown}
+        poweredDown={this.props.weaponData.requiresPlant && this.props.poweredDown}
       />
     )
   }

--- a/client/src/components/graphql/queries/completeMatchData.js
+++ b/client/src/components/graphql/queries/completeMatchData.js
@@ -27,6 +27,7 @@ const completeMatchData = gql`
             }
           }
         }
+        status
         time {
           phase {
             number

--- a/server/src/gameServerHelpers/PhasingMove.ts
+++ b/server/src/gameServerHelpers/PhasingMove.ts
@@ -257,6 +257,10 @@ class PhasingMove {
     }
 
     vehicle.phasing.controlChecksForSpeedChanges = vehicle.phasing.speedChanges.map((setting: any) => {
+      console.log({
+        speed: setting.speed,
+        checks: Control.row({ speed: setting.speed }),
+      })
       return {
         speed: setting.speed,
         checks: Control.row({ speed: setting.speed }),

--- a/server/src/gameServerHelpers/Vehicle.ts
+++ b/server/src/gameServerHelpers/Vehicle.ts
@@ -36,12 +36,13 @@ class Vehicle {
     // A "kill" is scored when an enemy vehicle can no longer move or fire, either
     // because of a direct attack, a crash during combat, surrender of the occupants,
     // or other circumstance
-    const statusKilled = typeof vehicle.status.killed !== 'undefined' && vehicle.status.killed === true
+    let result = typeof vehicle.status.killed !== 'undefined' && vehicle.status.killed === true
     const stopped = vehicle.status.speed === 0
     const noDriver = !Vehicle.driverAwake({ vehicle })
     const noPlant = !Vehicle.plantWorking({ vehicle })
     const noWeapons = Vehicle.weaponsOut({ vehicle })
-    const result = statusKilled || (stopped && (noDriver || (noPlant && noWeapons)))
+    result = result || noDriver
+    result = result || (noPlant && noWeapons && stopped)
     return result
   }
 

--- a/server/src/gameServerHelpers/settings/Speed.ts
+++ b/server/src/gameServerHelpers/settings/Speed.ts
@@ -27,7 +27,13 @@ class Speed {
       }
     }
 
-    if (speedChanged || bugMeNot) {
+    console.log()
+    console.log('===================')
+    console.log(vehicle.phasing.speedChanges)
+    console.log('===================')
+    console.log()
+
+    if (speedChanged || bugMeNot || vehicle.phasing.speedChanges.length == 1) {
       Log.info(`speed change: ${vehicle.status.speed}MPH -> ${newSpeed.speed}MPH`, vehicle)
       vehicle.status.speedSetThisTurn = true
     }

--- a/server/src/types/Car.ts
+++ b/server/src/types/Car.ts
@@ -358,7 +358,7 @@ export const resolvers = {
       const vehicle = Vehicle.withId({ id: args.id })
       const match = Match.withId({ id: vehicle.currentMatch })
       Speed.accept({ vehicle, match, bugMeNot: args.bugMeNot })
-      console.log('back here')
+      console.log('speed accepted')
     },
 
     setTarget: (parent: any, args: any) => {


### PR DESCRIPTION
No more prompting dead vehicles for changes.
Now end match when no more than 1 vehicle still alive.
Pop UI for match over.
Fix red-ed out weapons in inset when plant out unless they depend on
plant.